### PR TITLE
Fix install command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ node_js:
   - 0.8
   - '0.10'
 before_install:
-  - npm install - g npm
+  - npm install -g npm


### PR DESCRIPTION
I fixed typo. `- g` -> `-g`

-------

The only problem in the CI error is that npm v1.2 doesn't support the ^ version specifier. It's not the problem of Node v0.8 itself.
So I updated the installation command to install the latest version of npm, before installing the dependencies of this module.
