### PR TITLE
support specificed git dir other than default .git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.js
+++ b/index.js
@@ -3,8 +3,12 @@ var ini = require('ini');
 var path = require('path');
 
 
-module.exports = function(dir,cb){
-  findGit(dir,function(config) {
+module.exports = function(dir,options,cb){
+  if (typeof options === 'function') {
+    cb = options;
+    options = {};
+  }
+  findGit(dir,options,function(config) {
     if(!config) return cb(new Error('no gitconfig to be found at '+dir))
     fs.readFile(config,function(err,data){
       if(err) return cb(err);
@@ -31,14 +35,14 @@ function format(data){
       out[k] = data[k];
     }
   });
-  return out; 
+  return out;
 }
 
-function findGit(dir, cb) {
-  var folder = path.join(dir, '.git/config')
+function findGit(dir,options,cb){
+  var folder = path.resolve(dir, process.env.GIT_DIR || options.gitDir || '.git', 'config');
   fs.exists(folder,function(exists) {
-    if(exists) return cb(folder)
-    if(dir === path.resolve(dir, '..')) return cb(false)
-    findGit(path.resolve(dir, '..'), cb)
-  })
+    if(exists) return cb(folder);
+    if(dir === path.resolve(dir, '..')) return cb(false);
+    findGit(path.resolve(dir, '..'), options, cb);
+  });
 }

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ function format(data){
 }
 
 function findGit(dir,options,cb){
-  var folder = path.resolve(dir, process.env.GIT_DIR || options.gitDir || '.git', 'config');
+  var folder = path.resolve(dir, options.gitDir || process.env.GIT_DIR || '.git', 'config');
   fs.exists(folder,function(exists) {
     if(exists) return cb(folder);
     if(dir === path.resolve(dir, '..')) return cb(false);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "ini": "^1.3.2"
   },
   "devDependencies": {
+    "fs-extra": "^0.26.4",
     "tape": "^3.4.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
 var test = require('tape');
 var gitconfig = require('../index');
 var path = require('path');
+var fse = require('fs-extra');
 
 test("can get gitconfig",function(t) {
   gitconfig(path.resolve(__dirname,'..'),function(err,data){
@@ -18,3 +19,32 @@ test("can get gitconfig from subfolder",function(t) {
   });
 });
 
+var gitDir = path.resolve(__dirname,'..','_git'),
+  setUp = function() {
+    fse.mkdirpSync(gitDir);
+    fse.copySync(path.resolve(__dirname,'..','.git/config'), path.resolve(gitDir,'config'));
+  },
+  tearDown = function() {
+    fse.removeSync(gitDir);
+  };
+
+test('can get gitconfig in git dir other than default .git', function(t) {
+  setUp();
+  gitconfig(path.resolve(__dirname,'..'), {gitDir: '_git'}, function(err, data) {
+    t.ok(!err,'should not have error getting gitconfig');
+    t.ok(data,'should have config data');
+    tearDown();
+    t.end();
+  });
+});
+
+test('from subfolder can get gitconfig in $GIT_DIR (absolute path) other than default .git', function(t) {
+  setUp();
+  process.env.GIT_DIR = path.resolve(__dirname,'../_git');
+  gitconfig(__dirname, function(err, data) {
+    t.ok(!err,'should not have error getting gitconfig');
+    t.ok(data,'should have config data');
+    tearDown();
+    t.end();
+  });
+});


### PR DESCRIPTION
The git directory (default as `.git` in the repo) may be specified via `--git-dir` (git manual) or environment variable `$GIT_DIR` (though people barely do this) - https://git-scm.com/docs/git-init.
>If the $GIT_DIR environment variable is set then it specifies a path to use instead of ./.git for the base of the repository.