### PR TITLE
fixed: case: after remote without keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function format(data){
       if(!out[parentKey]) out[parentKey] = {};
       out[parentKey][childKey] = data[k];
     } else {
-      out[k] = data[k];
+      out[k] = {...out[k], ...data[k]};
     }
   });
   return out;

--- a/test/after-remote-without-key/_git/config
+++ b/test/after-remote-without-key/_git/config
@@ -1,0 +1,5 @@
+[remote "origin"]
+	url = https://example.com/repo.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+[remote]
+	pushDefault = origin

--- a/test/test.js
+++ b/test/test.js
@@ -48,3 +48,11 @@ test('from subfolder can get gitconfig in $GIT_DIR (absolute path) other than de
     t.end();
   });
 });
+
+test('after non key remote', function(t) {
+  process.env.GIT_DIR = "_git";
+  gitconfig(path.resolve(__dirname, 'after-remote-without-key'), function(err, data) {
+    t.ok(data && data.remote && data.remote.origin && data.remote.origin.url === 'https://example.com/repo.git', 'should have url');
+    t.end();
+  });
+})


### PR DESCRIPTION
[azu/github-label-setup: 📦 Setup GitHub label without
configuration.](https://github.com/azu/github-label-setup)
is not work my repo.
Then I fix to here.
The origin code support before without key section.
However not suppor after without key section.