### PR TITLE
feat: switch to promise-based api, drop support for node < 12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: test
+on:
+  - push
+  - pull_request
+jobs:
+  test:
+    name: Node.js ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 16
+          - 14
+          - 12
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-sudo: false
-language: node_js
-node_js:
-  - 12
-  - 14
-  - 16
-before_install:
-  - npm install -g npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - 6
-  - 8
-  - 10
+  - 12
+  - 14
+  - 16
 before_install:
   - npm install -g npm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,8 @@
-2.1.0
-adding suppport for other config layouts https://github.com/soldair/node-gitconfiglocal/pull/9
+## 3.0.0
+
+- switch to promise API
+- drop support for node < 12
+
+## 2.1.0
+
+- adding support for other config layouts https://github.com/soldair/node-gitconfiglocal/pull/9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 - switch to promise API
 - drop support for node < 12
+- add typescript definitions
 
 ## 2.1.0
 
-- adding support for other config layouts https://github.com/soldair/node-gitconfiglocal/pull/9
+- add support for other config layouts https://github.com/soldair/node-gitconfiglocal/pull/9

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,13 +10,13 @@ There are a few basic ground-rules for contributors:
 
 1. **No `--force` pushes** or modifying the Git history in any way.
 2. **External API changes and significant modifications** should be subject to a
-**pull request** to solicit feedback from other contributors.
-3. Pull requests to solicit feedback are *encouraged* for any other non-trivial
-contribution but left to the discretion of the contributor.
+   **pull request** to solicit feedback from other contributors.
+3. Pull requests to solicit feedback are _encouraged_ for any other non-trivial
+   contribution but left to the discretion of the contributor.
 4. Use a non-`master` branch for ongoing work.
 5. Contributors should attempt to adhere to the prevailing code style.
 6. Run `npm test` locally before submitting your PR to catch easy-to-miss style
-& testing issues
+   & testing issues
 
 ## Releases
 
@@ -28,6 +28,6 @@ This is an experiment and feedback is welcome! This document is subject to pull
 requests or changes by contributors where you believe you have something
 valuable to add or change.
 
-*Thanks to [Rod Vagg](https://github.com/rvagg) and the
+_Thanks to [Rod Vagg](https://github.com/rvagg) and the
 [LevelUP](https://github.com/rvagg/node-levelup) project for coming up with this
-model of open source contribution.*
+model of open source contribution._

--- a/README.md
+++ b/README.md
@@ -1,20 +1,17 @@
-
 [![Build Status](https://travis-ci.org/soldair/node-gitconfiglocal.svg?branch=master)](https://travis-ci.org/soldair/node-gitconfiglocal)
 
-gitconfiglocal
-==============
+# gitconfiglocal
 
 parse the `.git/config` file into a useful data structure
 
-
-example
-=======
+# example
 
 - search config in $GIT_DIR (.git by default)
+
 ```js
 var gitconfig = require('gitconfiglocal');
 
-gitconfig('./',function(err,config){
+gitconfig('./').then((config) => {
   console.log(config);
   /* prints:
   { core:
@@ -28,11 +25,10 @@ gitconfig('./',function(err,config){
           fetch: '+refs/heads/*:refs/remotes/origin/*' } } }
   */
 });
-
 ```
 
 - specify $GIT_DIR via options:
-```js
-gitconfig('./', { gitDir: 'path/to/gitdir' }, cb);
 
+```js
+gitconfig('./', { gitDir: 'path/to/gitdir' });
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 parse the `.git/config` file into a useful data structure
 
-# example
+## example
 
 - search config in $GIT_DIR (.git by default)
 
@@ -32,3 +32,7 @@ gitconfig('./').then((config) => {
 ```js
 gitconfig('./', { gitDir: 'path/to/gitdir' });
 ```
+
+## license
+
+licensed under the [3-Clause BSD license](./LICENSE).

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,12 @@
+declare namespace gitConfigLocal {
+  interface Options {
+    readonly gitDir?: string;
+  }
+}
+
+declare function gitConfigLocal(
+  dir: string,
+  options?: gitConfigLocal.Options
+): Promise<Record<string, any>>;
+
+export = gitConfigLocal;

--- a/index.js
+++ b/index.js
@@ -1,61 +1,48 @@
 //@ts-check
-var fs = require('fs');
-var ini = require('ini');
-var path = require('path');
+const fs = require('fs').promises;
+const ini = require('ini');
+const path = require('path');
 
+module.exports = async function gitConfigLocal(dir, options = {}) {
+  const config = await findGit(dir, options);
+  if (!config) throw new Error('no gitconfig to be found at ' + dir);
 
-module.exports = function(dir,options,cb){
-  if (typeof options === 'function') {
-    cb = options;
-    options = {};
-  }
-  findGit(dir,options,function(config) {
-    if(!config) return cb(new Error('no gitconfig to be found at '+dir))
-    fs.readFile(config,function(err,data){
-      if(err) return cb(err);
-      try{
-       var formatted = format(ini.parse(data.toString()));
-      } catch (e){
-       return cb(e);
-      }
-      cb(false,formatted);
-    })
-  })
-}
+  const data = await fs.readFile(config);
+  return format(ini.parse(data.toString()));
+};
 
-function format(data){
-  var out = {};
-  Object.keys(data).forEach(function(k){
-    if(k.indexOf('"')> -1) {
-      var parts = k.split('"');
-      var parentKey = parts.shift().trim();
-      var childKey = parts.shift().trim();
-      if(!out[parentKey]) out[parentKey] = {};
+function format(data) {
+  const out = {};
+  Object.keys(data).forEach(function (k) {
+    if (k.indexOf('"') > -1) {
+      const parts = k.split('"');
+      const parentKey = parts.shift().trim();
+      const childKey = parts.shift().trim();
+      if (!out[parentKey]) out[parentKey] = {};
       out[parentKey][childKey] = data[k];
     } else {
-      out[k] = merge(out[k],data[k])
-      // cant start using these without bumping the major
-      //out[k] = {...out[k], ...data[k]};
+      out[k] = { ...out[k], ...data[k] };
     }
   });
   return out;
 }
 
-function findGit(dir,options,cb){
-  var folder = path.resolve(dir, options.gitDir || process.env.GIT_DIR || '.git', 'config');
-  fs.exists(folder,function(exists) {
-    if(exists) return cb(folder);
-    if(dir === path.resolve(dir, '..')) return cb(false);
-    findGit(path.resolve(dir, '..'), options, cb);
-  });
+async function findGit(dir, options) {
+  const folder = path.resolve(
+    dir,
+    options.gitDir || process.env.GIT_DIR || '.git',
+    'config'
+  );
+
+  const exists = await pathExists(folder);
+  if (exists) return folder;
+  if (dir === path.resolve(dir, '..')) return false;
+  return findGit(path.resolve(dir, '..'), options);
 }
 
-function merge(){
-  var a = {}
-  for(var i=arguments.length;i>=0;--i){
-    Object.keys(arguments[i]||{}).forEach((k)=>{
-      a[k] = arguments[i][k]
-    })
-  }
-  return a;
+function pathExists(filePath) {
+  return fs.access(filePath).then(
+    () => true,
+    () => false
+  );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,411 @@
 {
   "name": "gitconfiglocal",
   "version": "2.1.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "gitconfiglocal",
+      "version": "2.1.0",
+      "license": "BSD",
+      "dependencies": {
+        "ini": "^1.3.2"
+      },
+      "devDependencies": {
+        "fs-extra": "^0.26.4",
+        "prettier": "^2.5.1",
+        "tape": "^4.10.1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
+    "node_modules/define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "dependencies": {
+        "object-keys": "^1.0.12"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
+    "node_modules/es-abstract": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "dev": true,
+      "dependencies": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
+      "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0",
+        "path-is-absolute": "^1.0.0",
+        "rimraf": "^2.2.8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "node_modules/glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "dev": true
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "node_modules/ini": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.6.tgz",
+      "integrity": "sha512-IZUoxEjNjubzrmvzZU4lKP7OnYmX72XRl3sqkfJhBKweKi5rnGi5+IUdlj/H1M+Ip5JQ1WzaDMOBRY90Ajc5jg==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/klaw": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "node_modules/object-inspect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+      "dev": true
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
+      "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+      "dev": true,
+      "dependencies": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "node_modules/resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
+      "dependencies": {
+        "through": "~2.3.4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/tape": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.10.1.tgz",
+      "integrity": "sha512-G0DywYV1jQeY3axeYnXUOt6ktnxS9OPJh97FGR3nrua8lhWi1zPflLxcAHavZ7Jf3qUfY7cxcVIVFa4mY2IY1w==",
+      "dev": true,
+      "dependencies": {
+        "deep-equal": "~1.0.1",
+        "defined": "~1.0.0",
+        "for-each": "~0.3.3",
+        "function-bind": "~1.1.1",
+        "glob": "~7.1.3",
+        "has": "~1.0.3",
+        "inherits": "~2.0.3",
+        "minimist": "~1.2.0",
+        "object-inspect": "~1.6.0",
+        "resolve": "~1.10.0",
+        "resumer": "~0.0.0",
+        "string.prototype.trim": "~1.1.2",
+        "through": "~2.3.8"
+      },
+      "bin": {
+        "tape": "bin/tape"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  },
   "dependencies": {
     "balanced-match": {
       "version": "1.0.0",
@@ -253,9 +656,15 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true
     },
     "resolve": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "node": ">=12.0.0"
   },
   "author": "Ryan Day",
-  "license": "BSD",
+  "license": "BSD-3-Clause",
   "readmeFilename": "README.md",
   "dependencies": {
     "ini": "^1.3.2"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "2.1.0",
   "description": "parse the .git/config file into a useful data structure",
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "scripts": {
     "test": "node test/test.js"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "git",
     "config"
   ],
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "author": "Ryan Day",
   "license": "BSD",
   "readmeFilename": "README.md",
@@ -24,6 +27,10 @@
   },
   "devDependencies": {
     "fs-extra": "^0.26.4",
+    "prettier": "^2.5.1",
     "tape": "^4.10.1"
+  },
+  "prettier": {
+    "singleQuote": true
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,58 +1,73 @@
-var test = require('tape');
-var gitconfig = require('../index');
-var path = require('path');
-var fse = require('fs-extra');
+const test = require('tape');
+const gitconfig = require('../index');
+const path = require('path');
+const fse = require('fs-extra');
 
-test("can get gitconfig",function(t) {
-  gitconfig(path.resolve(__dirname,'..'),function(err,data){
-    t.ok(!err,'should not have error getting gitconfig '+err);
-    t.ok(data,'should have config data');
-    t.end();
-  });
+test('can get gitconfig', function (t) {
+  gitconfig(path.resolve(__dirname, '..'))
+    .then((data) => {
+      t.ok(data, 'should have config data');
+      t.end();
+    })
+    .catch(t.end);
 });
 
-test("can get gitconfig from subfolder",function(t) {
-  gitconfig(__dirname,function(err,data){
-    t.ok(!err,'should not have error getting gitconfig');
-    t.ok(data,'should have config data');
-    t.end();
-  });
+test('can get gitconfig from subfolder', function (t) {
+  gitconfig(__dirname)
+    .then((data) => {
+      t.ok(data, 'should have config data');
+      t.end();
+    })
+    .catch(t.end);
 });
 
-var gitDir = path.resolve(__dirname,'..','_git'),
-  setUp = function() {
+const gitDir = path.resolve(__dirname, '..', '_git'),
+  setUp = function () {
     fse.mkdirpSync(gitDir);
-    fse.copySync(path.resolve(__dirname,'..','.git/config'), path.resolve(gitDir,'config'));
+    fse.copySync(
+      path.resolve(__dirname, '..', '.git/config'),
+      path.resolve(gitDir, 'config')
+    );
   },
-  tearDown = function() {
+  tearDown = function () {
     fse.removeSync(gitDir);
   };
 
-test('can get gitconfig in git dir other than default .git', function(t) {
+test('can get gitconfig in git dir other than default .git', function (t) {
   setUp();
-  gitconfig(path.resolve(__dirname,'..'), {gitDir: '_git'}, function(err, data) {
-    t.ok(!err,'should not have error getting gitconfig');
-    t.ok(data,'should have config data');
-    tearDown();
-    t.end();
-  });
+  gitconfig(path.resolve(__dirname, '..'), { gitDir: '_git' })
+    .then((data) => {
+      t.ok(data, 'should have config data');
+      tearDown();
+      t.end();
+    })
+    .catch(t.end);
 });
 
-test('from subfolder can get gitconfig in $GIT_DIR (absolute path) other than default .git', function(t) {
+test('from subfolder can get gitconfig in $GIT_DIR (absolute path) other than default .git', function (t) {
   setUp();
-  process.env.GIT_DIR = path.resolve(__dirname,'../_git');
-  gitconfig(__dirname, function(err, data) {
-    t.ok(!err,'should not have error getting gitconfig');
-    t.ok(data,'should have config data');
-    tearDown();
-    t.end();
-  });
+  process.env.GIT_DIR = path.resolve(__dirname, '../_git');
+  gitconfig(__dirname)
+    .then((data) => {
+      t.ok(data, 'should have config data');
+      tearDown();
+      t.end();
+    })
+    .catch(t.end);
 });
 
-test('after non key remote', function(t) {
-  process.env.GIT_DIR = "_git";
-  gitconfig(path.resolve(__dirname, 'after-remote-without-key'), function(err, data) {
-    t.ok(data && data.remote && data.remote.origin && data.remote.origin.url === 'https://example.com/repo.git', 'should have url');
-    t.end();
-  });
-})
+test('after non key remote', function (t) {
+  process.env.GIT_DIR = '_git';
+  gitconfig(path.resolve(__dirname, 'after-remote-without-key'))
+    .then((data) => {
+      t.ok(
+        data &&
+          data.remote &&
+          data.remote.origin &&
+          data.remote.origin.url === 'https://example.com/repo.git',
+        'should have url'
+      );
+      t.end();
+    })
+    .catch(t.end);
+});


### PR DESCRIPTION
👋  Thanks for authoring the module!

Things seems to be pretty settled on promises these days, so I figured maybe you'd accept a PR that switches the API to using them?

Also took the liberty of modernizing a bit by:
- dropping support for unsupported node.js versions
- using `const` over `var`
- adding typescript definitions
- using prettier for a more consistent coding style
- switching from travis to github actions

Obviously feel free to reject if you don't feel this makes sense :) 
